### PR TITLE
Filter undefined byline tokens

### DIFF
--- a/dotcom-rendering/src/lib/byline-tokens.amp.ts
+++ b/dotcom-rendering/src/lib/byline-tokens.amp.ts
@@ -4,8 +4,13 @@ export const bylineTokens = (
 	byline: string,
 	contributorTags: TagType[],
 ): string[] => {
-	const titles = contributorTags.map((c) => c.title);
+	const titles = contributorTags.map((c) => c.title).filter(Boolean);
+
+	if (titles.length === 0) {
+		return [byline];
+	}
+
 	const regex = new RegExp(`(${titles.join('|')})`);
 
-	return byline.split(regex);
+	return byline.split(regex).filter((token) => token !== undefined);
 };


### PR DESCRIPTION
## What does this change?

- Filters out empty or `undefined` contributor titles before creating the regex.
- If no valid contributor titles are present, the original byline is returned as a single token.
- Filters out `undefined` tokens from the array returned by `byline.split(regex)`.

## Why?

Previously, the `bylineTokens` function could return `undefined` values in the array, causing errors. This occurred when the `contributorTags` array was empty, leading to an invalid regex, or when `byline.split()` produced `undefined` tokens. These changes make the function more robust and prevent these errors.

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

---
<a href="https://cursor.com/background-agent?bcId=bc-da03eb95-5db5-4403-b17f-3f472e0897ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da03eb95-5db5-4403-b17f-3f472e0897ce">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

